### PR TITLE
reducing poop amount during filamentchange

### DIFF
--- a/ChangeFilament.gcode
+++ b/ChangeFilament.gcode
@@ -19,7 +19,8 @@ G1 X90 F3000
 G1 Y255 F4000
 G1 X100 F5000
 G1 X120 F15000
-
+G1 E-20 F200    ;Filament is pushed out 20 mm.
+M400                  ;Waits until pushing out is completed before doing anything else.
 G1 X20 Y50 F21000
 G1 Y-3
 {if toolchange_count == 2}
@@ -34,7 +35,9 @@ M620.1 E F[new_filament_e_feedrate] T{nozzle_temperature_range_high[next_extrude
 
 {if next_extruder < 255}
 M400
-
+G1 E18 F200   ;Filament is pushed back in 18 mm. 
+G1 E2 F20       ;Filament is pushed back in 2 mm but slower. 
+M400               ;Waits until pushing back in is completed before doing anything else.
 G92 E0
 {if flush_length_1 > 1}
 ; FLUSH_START

--- a/MachineEnd.gcode
+++ b/MachineEnd.gcode
@@ -14,6 +14,8 @@ M106 P2 S0 ; turn off remote part cooling fan
 M106 P3 S0 ; turn off chamber cooling fan
 
 G1 X100 F12000 ; wipe
+G1 E-20 F200   ;Filament is pushed out 20 mm. 
+M400                   ;Waits until pushing out is completed before doing anything else.  
 ; pull back filament to AMS
 M620 S255
 G1 X20 Y50 F12000

--- a/MachineStart.gcode
+++ b/MachineStart.gcode
@@ -69,7 +69,7 @@ M412 S1 ; ===turn on filament runout detection===
 M109 S250 ;set nozzle to common flush temp
 M106 P1 S0
 G92 E0
-G1 E50 F200
+G1 E70 F200 ; Here the E50 value was changed to E70 to extrude another 20mm
 M400
 M104 S[nozzle_temperature_initial_layer]
 G92 E0


### PR DESCRIPTION
This change in GCODE reduces the poop amount for each Filamentchange with AMS. Original poster: leon.fisher.skipper.18 https://makerworld.com/en/models/91241