### PR TITLE
Heated chamber

### DIFF
--- a/MachineEnd.gcode
+++ b/MachineEnd.gcode
@@ -8,14 +8,17 @@ G1 Y265 F3000
 
 G1 X65 Y245 F12000
 G1 Y265 F3000
-M140 S0 ; turn off bed
-M106 S0 ; turn off fan
-M106 P2 S0 ; turn off remote part cooling fan
-M106 P3 S0 ; turn off chamber cooling fan
+
+;The fans and bed will get the turn off command after chamber cooldown for following types of material: ASA, ABS, PA(Nylon), PA-CF(Nylon Carbonfibre)
+{if (filament_type[initial_tool]=="ASA") || (filament_type[initial_tool]=="ABS") || (filament_type[initial_tool]=="PA-CF") || (filament_type[initial_tool]=="PA")}
+{elsif} 
+    M140 S0 ; turn off bed
+    M106 S0 ; turn off fan
+    M106 P2 S0 ; turn off remote part cooling fan
+    M106 P3 S0 ; turn off chamber cooling fan
+{endif}
 
 G1 X100 F12000 ; wipe
-G1 E-20 F200   ;Filament is pushed out 20 mm. 
-M400                   ;Waits until pushing out is completed before doing anything else.  
 ; pull back filament to AMS
 M620 S255
 G1 X20 Y50 F12000
@@ -45,6 +48,48 @@ M17 Z0.4 ; lower z motor current to reduce impact if there is something in the b
     G1 Z250 F600
     G1 Z248
 {endif}
+
+;===== slow heatbed cooldown ====================
+; will be performed for the following types of material: ASA, ABS, PA(Nylon), PA-CF(Nylon Carbonfibre)
+{if (filament_type[initial_tool]=="ASA") || (filament_type[initial_tool]=="ABS") || (filament_type[initial_tool]=="PA-CF") || (filament_type[initial_tool]=="PA")}
+    M140 S90 ;set bed temperature to 90°C
+    G4 S90 ; wait 90 seconds
+    G4 S90 ; wait 90 seconds
+    G4 S90 ; wait 90 seconds
+    M190 S80 ;set bed temperature to 80°C
+    G4 S90 ; wait 90 seconds
+    G4 S90 ; wait 90 seconds
+    G4 S90 ; wait 90 seconds
+    M190 S70 ;set bed temperature to 70°C
+    G4 S90 ; wait 90 seconds
+    G4 S90 ; wait 90 seconds
+    G4 S90 ; wait 90 seconds
+    M190 S60 ;set bed temperature to 60°C
+    G4 S90 ; wait 90 seconds
+    G4 S90 ; wait 90 seconds
+    G4 S90 ; wait 90 seconds
+    M190 S55 ;set bed temperature to 55°C
+    G4 S90 ; wait 90 seconds
+    G4 S90 ; wait 90 seconds
+    G4 S90 ; wait 90 seconds
+    M190 S50 ;set bed temperature to 50°C
+    G4 S90 ; wait 90 seconds
+    G4 S90 ; wait 90 seconds
+    G4 S90 ; wait 90 seconds
+    M190 S45 ;set bed temperature to 45°C
+    G4 S90 ; wait 90 seconds
+    G4 S90 ; wait 90 seconds
+    G4 S90 ; wait 90 seconds
+    M190 S40 ;set bed temperature to 40°C
+    G4 S90 ; wait 90 seconds
+    G4 S90 ; wait 90 seconds
+    G4 S90 ; wait 90 seconds
+    M140 S0 ; turn off bed
+    M106 S0 ; turn off fan
+    M106 P2 S0 ; turn off remote part cooling fan
+    M106 P3 S0 ; turn off chamber cooling fan
+{endif}
+
 M400 P100
 M17 R ; restore z current
 

--- a/MachineEnd.gcode
+++ b/MachineEnd.gcode
@@ -11,7 +11,7 @@ G1 Y265 F3000
 
 ;The fans and bed will get the turn off command after chamber cooldown for following types of material: ASA, ABS, PA(Nylon), PA-CF(Nylon Carbonfibre)
 {if (filament_type[initial_tool]=="ASA") || (filament_type[initial_tool]=="ABS") || (filament_type[initial_tool]=="PA-CF") || (filament_type[initial_tool]=="PA")}
-{elsif} 
+{else} 
     M140 S0 ; turn off bed
     M106 S0 ; turn off fan
     M106 P2 S0 ; turn off remote part cooling fan

--- a/MachineEnd.gcode
+++ b/MachineEnd.gcode
@@ -19,6 +19,8 @@ G1 Y265 F3000
 {endif}
 
 G1 X100 F12000 ; wipe
+G1 E-20 F200   ;Filament is pushed out 20 mm. 
+M400           ;Waits until pushing out is completed before doing anything else.  
 ; pull back filament to AMS
 M620 S255
 G1 X20 Y50 F12000

--- a/MachineStart.gcode
+++ b/MachineStart.gcode
@@ -91,7 +91,7 @@ M412 S1 ; ===turn on filament runout detection===
 M109 S250 ;set nozzle to common flush temp
 M106 P1 S0
 G92 E0
-G1 E50 F200
+G1 E70 F200 ; Here the E50 value was changed to E70 to extrude another 20mm
 M400
 M104 S[nozzle_temperature_initial_layer]
 G92 E0

--- a/MachineStart.gcode
+++ b/MachineStart.gcode
@@ -28,7 +28,6 @@ M140 S[bed_temperature_initial_layer_single] ;set bed temp
 M190 S[bed_temperature_initial_layer_single] ;wait for bed temp
 
 
-
 ;=============turn on fans to prevent PLA jamming=================
 {if filament_type[initial_extruder]=="PLA"}
     {if (bed_temperature[initial_extruder] >45)||(bed_temperature_initial_layer[initial_extruder] >45)}
@@ -37,7 +36,30 @@ M190 S[bed_temperature_initial_layer_single] ;wait for bed temp
     M106 P3 S255
     {endif};Prevent PLA from jamming
 {endif}
-M106 P2 S100 ; turn on big fan ,to cool down toolhead
+M106 P2 S100 ; turn on aux fan ,to cool down toolhead
+
+;===== HEATING OF CHAMBER ====================
+; will be performed for the following types of material: ASA, ABS, PA(Nylon), PA-CF(Nylon Carbonfibre)
+{if (filament_type[initial_tool]=="ASA") || (filament_type[initial_tool]=="ABS") || (filament_type[initial_tool]=="PA-CF") || (filament_type[initial_tool]=="PA")}
+    M106 P2 S255 ; turn ON aux fan at full speed to distribute the heat as fast as possible
+    M106 P3 S0 ; turn OFF chamber fan that chamber heats up as strong as possible
+    ; the following G4 commands sum up to a waiting time of 20 minutes
+    G4 S90 ; wait 1min30sec or 90 seconds
+    G4 S90 ; wait 90 seconds
+    G4 S90 ; wait 90 seconds
+    G4 S90 ; wait 90 seconds
+    G4 S90 ; wait 90 seconds
+    G4 S90 ; wait 90 seconds    
+    G4 S90 ; wait 90 seconds    
+    G4 S90 ; wait 90 seconds    
+    G4 S90 ; wait 90 seconds    
+    G4 S90 ; wait 90 seconds    
+    G4 S90 ; wait 90 seconds   
+    G4 S90 ; wait 90 seconds   
+    G4 S90 ; wait 90 seconds   
+    G4 S90 ; wait 30 seconds   
+    M106 P2 S0 ; turn OFF aux fan
+{endif}
 
 ;===== prepare print temperature and material ==========
 M104 S[nozzle_temperature_initial_layer] ;set extruder temp
@@ -69,7 +91,7 @@ M412 S1 ; ===turn on filament runout detection===
 M109 S250 ;set nozzle to common flush temp
 M106 P1 S0
 G92 E0
-G1 E70 F200 ; Here the E50 value was changed to E70 to extrude another 20mm
+G1 E50 F200
 M400
 M104 S[nozzle_temperature_initial_layer]
 G92 E0


### PR DESCRIPTION
### Machine Start GCODE:
**integrated heating up of chamber**

- for Filament types: ASA, ABS, PA (Nylon) and PA-CF
- chamber heats up for 20 minutes (13 x 90 seconds plus 30 seconds as a longer time did not work in one command)
- aux fan will be active during heating phase to distribute the heat
- after heatup phase aux fan and chamber fan are switched off


### Machine End GCODE:
**integrated slow cooldown of chamber**

-  for Filament types: ASA, ABS, PA (Nylon) and PA-CF the bed and fans will not be switched of at cooldown phase
- iteration of lowering the bed temperature from 90°C to 40°C with time delays of 4,5mins between each steps
- after ramped cooldown bed and fans will be switched of